### PR TITLE
Fix/delete event

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     "import/prefer-default-export": "off",
     "class-methods-use-this": "off",
     "no-underscore-dangle": "off",
+    "no-restricted-syntax": "off",
   },
 };

--- a/src/schema/resolvers/invitation/query.resolver.js
+++ b/src/schema/resolvers/invitation/query.resolver.js
@@ -1,8 +1,11 @@
 // get all user invitations
+import { InvitationStatus } from "../../../utils/constants";
+
 const getInvitations = async (_, args, context) => {
   const { data: allInvitations } = await context.database.invitations.find({
     attendeeId: args.userId,
     eventId: args.eventId,
+    $nor: [{ status: InvitationStatus.cancelled }],
   });
 
   return allInvitations;


### PR DESCRIPTION
- Mark pending or accepted invitations as cancelled if associated event is deleted
- Do not show cancelled events from list of results